### PR TITLE
feat: Simplify build using java-locator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ test_util = []
 use_existing_hdfs = []
 
 [build-dependencies]
-cc = "1.0"
-bindgen = "0.64.0"
+cc = "1"
+bindgen = "0.71.1"
+java-locator = { version = "0.1.9", features = ["locate-jdk-only"] }
 
 [dependencies]
 lazy_static = "^1.4"
@@ -35,4 +36,3 @@ log = "^0.4"
 [dev-dependencies]
 uuid = {version = "^0.8", features = ["v4"]}
 tempfile = "^3.2"
-filepath = "^0.1"

--- a/build.rs
+++ b/build.rs
@@ -120,32 +120,21 @@ fn get_build_flags() -> Vec<String> {
 fn get_java_dependency() -> Vec<String> {
     let mut result = vec![];
 
-    match env::var("JAVA_HOME") {
-        Ok(val) => {
-            result.push(format!("-I{}/include", val));
-            if cfg!(target_os = "linux") {
-                result.push(format!("-I{}/include/linux", val));
-                // for openjdk 8
-                println!(
-                    "cargo:rustc-link-search=native={}/jre/lib/amd64/server",
-                    val
-                );
-                // for openjdk 11, etc.
-                println!("cargo:rustc-link-search=native={}/lib/server", val)
-            } else if cfg!(target_os = "macos") {
-                result.push(format!("-I{}/include/darwin", val));
-                // for openjdk 8
-                println!("cargo:rustc-link-search=native={}/jre/lib/server", val);
-                // for openjdk 11, etc.
-                println!("cargo:rustc-link-search=native={}/lib/server", val);
-            }
-            // Tell cargo to tell rustc to link the system jvm shared library.
-            println!("cargo:rustc-link-lib=jvm");
-        }
-        Err(e) => {
-            panic!("JAVA_HOME shell environment must be set: {}", e);
-        }
-    }
+    // Include directories
+    let java_home = java_locator::locate_java_home()
+        .expect("JAVA_HOME could not be found, trying setting the variable manually");
+    result.push(format!("-I{java_home}/include"));
+    #[cfg(target_os = "linux")]
+    result.push(format!("-I{java_home}/include/linux"));
+
+    // libjvm link
+    let jvm_lib_location = java_locator::locate_jvm_dyn_library().unwrap();
+    println!("cargo:rustc-link-search=native={}", jvm_lib_location);
+    println!("cargo:rustc-link-lib=jvm");
+
+    // For tests, add libjvm path to rpath, this does not propagate upwards,
+    // unless building an .so, as per Cargo specs, so is only used when testing
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_lib_location}");
 
     result
 }


### PR DESCRIPTION
Using java-locator we no longer have to specify JAVA_HOME for a build, it can be done only at runtime(and preferably letting the Java application set it itself), this also resolves the various issues with jdk-8/11 and the varying file locations that have changed over the years, as it will search for the root java dir, which gives directly access to the headers, and only then searches for the libjvm recursively in directories within the root dir.

I've added the libjvm's path to the RPATH, for tests, this does not propagate to rlibs, so is only relevant for the test binary.